### PR TITLE
Fix #15: Correct malformed className in Button component

### DIFF
--- a/packages/client/src/components/common/Button.jsx
+++ b/packages/client/src/components/common/Button.jsx
@@ -35,7 +35,7 @@ export default function Button({
       {...props}
     >
       {loading && (
-        <svg className="animate-spin -ml-1 mr-2 h-4 w-4\" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
         </svg>


### PR DESCRIPTION
## Description
This PR fixes the malformed className string in the Button component's loading spinner.

## Changes
- Fixed the className attribute on line 38 of Button.jsx from `w-4\"` to `w-4"`
- The backslash before the closing quote was causing a syntax error

## Issue
Fixes #15

## Testing
The fix corrects the malformed className string that was preventing the loading spinner from rendering correctly.