### PR TITLE
fix: change progress bar color from blue to green

### DIFF
--- a/packages/client/src/components/campaigns/ProgressBar.jsx
+++ b/packages/client/src/components/campaigns/ProgressBar.jsx
@@ -12,7 +12,7 @@ export default function ProgressBar({ currentAmount, goalAmount, showText = true
     <div>
       <div className={`w-full bg-gray-200 rounded-full ${heightClasses[size] || heightClasses.md}`}>
         <div
-          className={`bg-blue-500 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
+          className={`bg-green-600 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
         />
       </div>


### PR DESCRIPTION
## Quickfix

**What**: Change progress bar color from blue to green
**Why**: Fixes #1 - progress bar should match site color scheme
**File**: packages/client/src/components/campaigns/ProgressBar.jsx

Changed `bg-blue-500` to `bg-green-600` to match the green color scheme used elsewhere in the app.

🔧 Created with /gbm.quickfix

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author