### PR TITLE
Fix #1: Change progress bar color from blue to green

### DIFF
--- a/packages/client/src/components/campaigns/ProgressBar.jsx
+++ b/packages/client/src/components/campaigns/ProgressBar.jsx
@@ -12,7 +12,7 @@ export default function ProgressBar({ currentAmount, goalAmount, showText = true
     <div>
       <div className={`w-full bg-gray-200 rounded-full ${heightClasses[size] || heightClasses.md}`}>
         <div
-          className={`bg-blue-500 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
+          className={`bg-green-600 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
         />
       </div>


### PR DESCRIPTION
## Summary
Fixes #1 - Progress bar now displays in green instead of blue.

## Changes
- Changed `bg-blue-500` to `bg-green-600` in ProgressBar component
- Ensures visual consistency with CampaignCard progress bar
- Aligns with site's green color scheme

## Testing
- [x] Code change applied
- [ ] Visual verification needed: Start dev server and verify progress bars appear green

## Files Changed
- `packages/client/src/components/campaigns/ProgressBar.jsx` (1 line)

## Risk Assessment
- **Risk Level**: Very Low
- **Impact**: Visual only (CSS class change)
- **Breaking Changes**: None

Closes #1