### PR TITLE
feat: add sort dropdown to campaign browse page

### DIFF
--- a/.gobuildme/specs/lite-sort-dropdown-campaign-list/mode.yaml
+++ b/.gobuildme/specs/lite-sort-dropdown-campaign-list/mode.yaml
@@ -1,0 +1,4 @@
+mode: lite
+created: "2026-01-30T12:15:00Z"
+estimated_files: 1
+estimated_loc: 25

--- a/.gobuildme/specs/lite-sort-dropdown-campaign-list/plan.md
+++ b/.gobuildme/specs/lite-sort-dropdown-campaign-list/plan.md
@@ -1,0 +1,17 @@
+# Lite Plan: sort-dropdown-campaign-list
+
+## Change Summary
+Add a sort dropdown to the Browse Campaigns page allowing users to sort by newest, most funded, and ending soon. Backend API already supports `sort` and `order` query parameters.
+
+## Files to Modify
+- `packages/client/src/pages/BrowseCampaigns.jsx` - Add sort state, dropdown UI, and pass params to API
+
+## Approach
+- Add `sortOptions` array with values: newest, most_funded, ending_soon
+- Add `sort` state variable (default: 'newest')
+- Add sort dropdown next to category dropdown
+- Update `fetchCampaigns` to include sort/order params
+- Add sort to useEffect dependencies
+
+## Risks/Notes
+- None - straightforward UI addition using existing API support

--- a/.gobuildme/specs/lite-sort-dropdown-campaign-list/request.md
+++ b/.gobuildme/specs/lite-sort-dropdown-campaign-list/request.md
@@ -1,0 +1,10 @@
+# Lite Request
+
+**What**: Add sort dropdown to campaign browse page (newest, most funded, ending soon)
+
+**Why**: Fixes issue #9 - backend API already supports sort params, frontend just needs UI
+
+**Scope**: 1 file, ~25 lines
+
+**Files likely affected**:
+- packages/client/src/pages/BrowseCampaigns.jsx

--- a/.gobuildme/specs/lite-sort-dropdown-campaign-list/tasks.md
+++ b/.gobuildme/specs/lite-sort-dropdown-campaign-list/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: sort-dropdown-campaign-list
+
+- [x] Add sortOptions array and sort state to BrowseCampaigns.jsx
+- [x] Add sort dropdown UI next to category dropdown
+- [x] Update fetchCampaigns to pass sort/order query params
+- [x] Run tests and fix any failures
+- [x] Self-review changes

--- a/packages/client/src/pages/BrowseCampaigns.jsx
+++ b/packages/client/src/pages/BrowseCampaigns.jsx
@@ -14,11 +14,18 @@ const categories = [
   { value: 'emergency', label: 'Emergency' },
 ]
 
+const sortOptions = [
+  { value: 'newest', label: 'Newest', sort: 'createdAt', order: 'desc' },
+  { value: 'most_funded', label: 'Most Funded', sort: 'currentAmount', order: 'desc' },
+  { value: 'ending_soon', label: 'Ending Soon', sort: 'endDate', order: 'asc' },
+]
+
 export default function BrowseCampaigns() {
   const [campaigns, setCampaigns] = useState([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('all')
+  const [sortBy, setSortBy] = useState('newest')
   const [pagination, setPagination] = useState({ page: 1, totalPages: 1 })
 
   const fetchCampaigns = async (page = 1) => {
@@ -32,6 +39,12 @@ export default function BrowseCampaigns() {
       if (search) params.append('search', search)
       if (category !== 'all') params.append('category', category)
 
+      const selectedSort = sortOptions.find(opt => opt.value === sortBy)
+      if (selectedSort) {
+        params.append('sort', selectedSort.sort)
+        params.append('order', selectedSort.order)
+      }
+
       const data = await api.get(`/campaigns?${params}`)
       setCampaigns(data.campaigns)
       setPagination(data.pagination)
@@ -44,7 +57,7 @@ export default function BrowseCampaigns() {
 
   useEffect(() => {
     fetchCampaigns(1)
-  }, [search, category])
+  }, [search, category, sortBy])
 
   const handleSearch = (e) => {
     e.preventDefault()
@@ -75,6 +88,18 @@ export default function BrowseCampaigns() {
             {categories.map((cat) => (
               <option key={cat.value} value={cat.value}>
                 {cat.label}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+            className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+          >
+            {sortOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary

Add sort dropdown to campaign browse page (newest, most funded, ending soon).
Fixes issue #9 - backend API already supports sort params, frontend just needed UI.

## Lite Workflow

This PR was created using lite workflow (3-5 files, ≤100 LoC).
- Skipped comprehensive review
- Passed: build validation

## Files Changed

- `packages/client/src/pages/BrowseCampaigns.jsx`

## Checklist

- [x] Tests pass (no test suite configured)
- [x] Build compiles
- [x] Self-reviewed

Closes #9

🔧 Created with /gbm.lite