### PR TITLE
🐛 Fix: show campaign creation error

### DIFF
--- a/.gobuildme/specs/quickfix-issue5/mode.yaml
+++ b/.gobuildme/specs/quickfix-issue5/mode.yaml
@@ -1,0 +1,3 @@
+mode: quickfix
+created: "2026-01-30T18:43:45Z"
+

--- a/.gobuildme/specs/quickfix-issue5/quickfix-log.md
+++ b/.gobuildme/specs/quickfix-issue5/quickfix-log.md
@@ -4,6 +4,6 @@
 **Why**: Failures were only logged to console; users got no feedback.
 **Files**: `packages/client/src/pages/CreateCampaign.jsx`
 **Lines changed**: 6
-**PR**: pending
+**PR**: https://github.com/Gauntlet-HQ/yes-build-me/pull/23
 **Timestamp**: 2026-01-30T18:43:45Z
 

--- a/.gobuildme/specs/quickfix-issue5/quickfix-log.md
+++ b/.gobuildme/specs/quickfix-issue5/quickfix-log.md
@@ -1,0 +1,9 @@
+# Quickfix: issue5-campaign-create-error
+
+**What**: Display campaign creation errors in the form error box.
+**Why**: Failures were only logged to console; users got no feedback.
+**Files**: `packages/client/src/pages/CreateCampaign.jsx`
+**Lines changed**: 6
+**PR**: pending
+**Timestamp**: 2026-01-30T18:43:45Z
+

--- a/.gobuildme/specs/quickfix-issue5/request.md
+++ b/.gobuildme/specs/quickfix-issue5/request.md
@@ -1,0 +1,6 @@
+# Quickfix
+
+**What**: Show an error message when campaign creation fails.
+**Why**: Users currently see no feedback on server errors.
+**File(s)**: `packages/client/src/pages/CreateCampaign.jsx`
+

--- a/packages/client/src/pages/CreateCampaign.jsx
+++ b/packages/client/src/pages/CreateCampaign.jsx
@@ -16,8 +16,10 @@ export default function CreateCampaign() {
       const campaign = await api.post('/campaigns', data)
       navigate(`/campaigns/${campaign.id}`)
     } catch (err) {
-      // Bug: Error not being displayed to user
-      console.log(err)
+      // Show error in the UI (red error box)
+      const message = err instanceof Error ? err.message : 'Failed to create campaign'
+      setError(message)
+      console.error('Create campaign error:', err)
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- Show a user-visible error message when campaign creation fails.

## Problem
- The Create Campaign flow swallowed API errors (console-only), so users got no feedback.

## Fix
- On failure, set the component error state so the existing red error banner renders.

## Files changed
- `packages/client/src/pages/CreateCampaign.jsx`

## Test plan
- Stop the API server (or force a 500 response).
- Submit the Create Campaign form.
- Verify the red error box at the top displays the error message.

## Issue
- Fixes #5