### PR TITLE
fix: change progress bar color from blue to green

### DIFF
--- a/packages/client/src/components/campaigns/ProgressBar.jsx
+++ b/packages/client/src/components/campaigns/ProgressBar.jsx
@@ -12,7 +12,7 @@ export default function ProgressBar({ currentAmount, goalAmount, showText = true
     <div>
       <div className={`w-full bg-gray-200 rounded-full ${heightClasses[size] || heightClasses.md}`}>
         <div
-          className={`bg-blue-500 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
+          className={`bg-green-500 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
         />
       </div>


### PR DESCRIPTION
## Summary
- Changed progress bar color from blue (`bg-blue-500`) to green (`bg-green-500`) in `ProgressBar.jsx`
- Matches the site's green color scheme (consistent with overfunded message styling)

## Test Plan
- [x] Visual verification that progress bar displays green
- [x] No functional changes, color-only fix

Fixes #1