### PR TITLE
fix: add text truncation to campaign card title and description

### DIFF
--- a/packages/client/src/components/campaigns/CampaignCard.jsx
+++ b/packages/client/src/components/campaigns/CampaignCard.jsx
@@ -37,11 +37,11 @@ export default function CampaignCard({ campaign }) {
             {campaign.category}
           </span>
 
-          <h3 className="mt-2 text-lg font-semibold text-gray-900">
+          <h3 className="mt-2 text-lg font-semibold text-gray-900 line-clamp-2">
             {campaign.title}
           </h3>
 
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-gray-600 line-clamp-3">
             {campaign.description}
           </p>
 


### PR DESCRIPTION
## Summary
- Added `line-clamp-2` to campaign title (max 2 lines with ellipsis)
- Added `line-clamp-3` to campaign description (max 3 lines with ellipsis)
- Prevents text overflow from breaking card layout

## Test Plan
- [x] Long titles truncate at 2 lines with ellipsis
- [x] Long descriptions truncate at 3 lines with ellipsis
- [x] Card layout remains consistent

Fixes #2