### PR TITLE
Fix campaign card text overflow with line-clamp truncation

### DIFF
--- a/packages/client/src/components/campaigns/CampaignCard.jsx
+++ b/packages/client/src/components/campaigns/CampaignCard.jsx
@@ -37,11 +37,11 @@ export default function CampaignCard({ campaign }) {
             {campaign.category}
           </span>
 
-          <h3 className="mt-2 text-lg font-semibold text-gray-900">
+          <h3 className="mt-2 text-lg font-semibold text-gray-900 line-clamp-2">
             {campaign.title}
           </h3>
 
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-gray-600 line-clamp-3">
             {campaign.description}
           </p>
 


### PR DESCRIPTION
## Summary

Fixes #2 - Campaign card text overflows instead of truncating.

## Changes

Added Tailwind `line-clamp` utilities to `CampaignCard.jsx`:
- Title (`<h3>`): Added `line-clamp-2` to truncate to 2 lines max
- Description (`<p>`): Added `line-clamp-3` to truncate to 3 lines max

## Before
Long campaign titles and descriptions overflow their containers, breaking the card layout.

## After
Text is properly truncated with ellipsis:
- Title: max 2 lines
- Description: max 3 lines

## Testing
- [x] Lint passes for `CampaignCard.jsx`
- [x] Tailwind v4 includes `line-clamp-*` utilities by default

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author