### PR TITLE
fix: display error message when campaign creation fails

### DIFF
--- a/packages/client/src/pages/CreateCampaign.jsx
+++ b/packages/client/src/pages/CreateCampaign.jsx
@@ -16,8 +16,7 @@ export default function CreateCampaign() {
       const campaign = await api.post('/campaigns', data)
       navigate(`/campaigns/${campaign.id}`)
     } catch (err) {
-      // Bug: Error not being displayed to user
-      console.log(err)
+      setError(err.message)
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary

Fix error handling in campaign creation form. When campaign creation fails (e.g., server error), the error message is now properly displayed to the user in the red error box at the top of the form.

## Problem

Previously, errors were only logged to console (`console.log(err)`), leaving users with no feedback when something went wrong.

## Solution

Changed to `setError(err.message)` to populate the existing error UI, matching the pattern used in `EditCampaign.jsx`.

## Files Changed

- `packages/client/src/pages/CreateCampaign.jsx` - Fixed error handling in catch block

## Checklist

- [x] Self-reviewed
- [x] Follows existing code patterns

Closes: Gauntlet-HQ/yes-build-me#5

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author