### PR TITLE
fix: truncate campaign card title and description text

### DIFF
--- a/.gobuildme/metadata/specs/quickfix-campaign-card-truncation.yaml
+++ b/.gobuildme/metadata/specs/quickfix-campaign-card-truncation.yaml
@@ -1,0 +1,11 @@
+feature: quickfix-campaign-card-truncation
+stages:
+  request:
+    created_at: '2026-01-30T19:06:58.860198Z'
+    created_by: Vicky Kieu
+    artifact: /Users/vkieu/workspace/yes-build-me/.gobuildme/specs/quickfix-campaign-card-truncation/request.md
+    input_summary_source: parameter
+    input_summary: &id001
+    - '[Goal 1]'
+    - '[Goal 2]'
+input_summary: *id001

--- a/.gobuildme/specs/quickfix-campaign-card-truncation/mode.yaml
+++ b/.gobuildme/specs/quickfix-campaign-card-truncation/mode.yaml
@@ -1,0 +1,2 @@
+mode: quickfix
+created: "2026-01-30T12:00:00Z"

--- a/.gobuildme/specs/quickfix-campaign-card-truncation/quickfix-log.md
+++ b/.gobuildme/specs/quickfix-campaign-card-truncation/quickfix-log.md
@@ -1,0 +1,8 @@
+# Quickfix: campaign-card-truncation
+
+**What**: Add line-clamp CSS to truncate overflowing campaign card text
+**Why**: Long titles/descriptions break card layout (Issue #2)
+**Files**: packages/client/src/components/campaigns/CampaignCard.jsx
+**Lines changed**: 4
+**PR**: pending
+**Timestamp**: 2026-01-30T12:00:00Z

--- a/.gobuildme/specs/quickfix-campaign-card-truncation/request.md
+++ b/.gobuildme/specs/quickfix-campaign-card-truncation/request.md
@@ -1,0 +1,5 @@
+# Quickfix
+
+**What**: Add line-clamp CSS to truncate campaign card title (2 lines) and description (3 lines)
+**Why**: Long text overflows card containers, breaking layout (Issue #2)
+**File(s)**: packages/client/src/components/campaigns/CampaignCard.jsx

--- a/packages/client/src/components/campaigns/CampaignCard.jsx
+++ b/packages/client/src/components/campaigns/CampaignCard.jsx
@@ -37,11 +37,11 @@ export default function CampaignCard({ campaign }) {
             {campaign.category}
           </span>
 
-          <h3 className="mt-2 text-lg font-semibold text-gray-900">
+          <h3 className="mt-2 text-lg font-semibold text-gray-900 line-clamp-2">
             {campaign.title}
           </h3>
 
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-gray-600 line-clamp-3">
             {campaign.description}
           </p>
 


### PR DESCRIPTION
Add line-clamp-2 to title and line-clamp-3 to description to prevent text overflow in campaign cards.

Fixes #2
Files: packages/client/src/components/campaigns/CampaignCard.jsx