### PR TITLE
fix: change progress bar color from blue to green (Fix #1)

### DIFF
--- a/packages/client/src/components/campaigns/ProgressBar.jsx
+++ b/packages/client/src/components/campaigns/ProgressBar.jsx
@@ -12,7 +12,7 @@ export default function ProgressBar({ currentAmount, goalAmount, showText = true
     <div>
       <div className={`w-full bg-gray-200 rounded-full ${heightClasses[size] || heightClasses.md}`}>
         <div
-          className={`bg-blue-500 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
+          className={`bg-green-600 ${heightClasses[size] || heightClasses.md} rounded-full transition-all duration-500`}
           style={{ width: `${percentage}%` }}
         />
       </div>


### PR DESCRIPTION
## Summary
Fixes #1 — Progress bar shows wrong color.

## Changes
- `packages/client/src/components/campaigns/ProgressBar.jsx`: change fill color from `bg-blue-500` to `bg-green-600` so it matches the progress bars used in CampaignCard and CampaignDetail.

## Verification
- No lint errors.
- Progress bar fill is now green (consistent with rest of app).